### PR TITLE
Added fly.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 node_modules/
 dist/
-# config for fly.io version used for public conformance testing
-fly.toml
 .DS_Store
 docs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine AS packages
+FROM node:14-alpine AS packages
 
 ADD package.json /app/package.json
 

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,38 @@
+# fly.toml file generated for sero
+# used to run public infrastructure for conformance testing, not suitable for any other use
+
+app = "sero"
+
+kill_signal = "SIGINT"
+kill_timeout = 5
+
+[env]
+
+[experimental]
+  allowed_public_ports = []
+  auto_rollback = true
+
+[[services]]
+  http_checks = []
+  internal_port = 8080
+  protocol = "tcp"
+  script_checks = []
+
+  [services.concurrency]
+    hard_limit = 25
+    soft_limit = 20
+    type = "connections"
+
+  [[services.ports]]
+    handlers = ["http"]
+    port = 80
+
+  [[services.ports]]
+    handlers = ["tls", "http"]
+    port = 443
+
+  [[services.tcp_checks]]
+    grace_period = "1s"
+    interval = "15s"
+    restart_limit = 6
+    timeout = "2s"


### PR DESCRIPTION
@mseckykoebel in the Loom I sent, I referenced this file existing. I actually had gitignored it.

This specific Fly config is for the deployment at sero.fly.dev - which I use for public testing (and the Logica sandbox example). I'm committing it to the repo as reference, but if you want to use Fly yourself you'll need to overrwrite this config with your own (the app name space is unique).

Relates to #12 in that Fly will be used for conformance testing, and this config file is necessary