### PR TITLE
FHIR Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@ Serotinous trees like the sequoia only spread when they are [exposed to the heat
 Health data is spreading everywhere. FHIR is a big part of that. Sero is built for developers who need tools in the languages they know, with opinionated answers to solve common problems.
 
 Features:
-- Multiple feature-specific composable modules
-- REST API implementation for [FHIR](https://www.hl7.org/fhir/http.html) with base R4 resources and unfinished operations
-- A functional [CDS Hooks](#cds-hooks) Service implementation
+- Multiple feature-specific composable modules - including http clients and servers
+- A minimal HTTP client for FHIR RESTful API operations as wrapper for [Fetch](https://fetch.spec.whatwg.org/)
+- A conformant (1.0 and 1.1) [CDS Hooks](#cds-hooks) Service implementation
+- An unfinished REST API implementation for [FHIR](https://www.hl7.org/fhir/http.html) with base R4 resources
 - Alpha In-memory Store design for persisting FHIR as a log
-- Out of box typings support for FHIR R4 with generics, CDS Hooks
+- Out of box typings support for FHIR R3 and R4 with generics, CDS Hooks
 
 Roadmap:
 - Resource specific routing engine
@@ -34,6 +35,7 @@ Roadmap:
 ## Table of Contents
 * [Quick Start](#quick-start)
 * [Docs](#docs)
+* [Client](#client)
 * [CDS Hooks](#cds-hooks)
 * [FHIR REST API](#rest)
 * [Development](#development)
@@ -54,6 +56,15 @@ npm start
 ### Docs
 
 Documentation built from code is available on the `gh-pages` branch and at [docs.sero.run](https://docs.sero.run)
+
+### Client
+
+A Fetch-ful FHIR client. Easily read a Patient resource or most other FHIR operations as a thin wrapper over Fetch.
+
+```typescript
+  const { read } = Client("https://r4.smarthealthit.org", {})
+  await read("Patient", "87a339d0-8cae-418e-89c7-8651e6aab3c6").json() as fhir4.Patient;
+```
 
 ### CDS Hooks
 
@@ -78,7 +89,7 @@ Building support for this protocol as a distribution/access channel for novel cl
 
 ### REST
 
-Serotiny exposes a `Rest` service that adds routes for `batch`, `capabilityStatement`, `instanceOperations`, and `typeOperations` routes and handlers.
+Sero exposes a `Rest` service that adds routes for `batch`, `capabilityStatement`, `instanceOperations`, and `typeOperations` routes and handlers.
 
 It consomes an instance of `http` and appends the configurable list above.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.3",
       "license": "Apache 2.0",
       "dependencies": {
+        "cross-fetch": "^3.1.4",
         "fastify": "^3.18.0"
       },
       "devDependencies": {
@@ -2558,6 +2559,14 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "node_modules/cross-fetch": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
+      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
+      "dependencies": {
+        "node-fetch": "2.6.1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -5886,6 +5895,14 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -9661,6 +9678,14 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
+    "cross-fetch": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
+      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
+      "requires": {
+        "node-fetch": "2.6.1"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -12205,6 +12230,11 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
+    },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-int64": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "eslint . && tsc",
     "start": "node dist/example/index.js",
     "test": "jest --detectOpenHandles",
-    "docs": "typedoc src/index.ts src/cds-hooks/index.ts src/http/index.ts src/rest/index.ts --readme ./README.md",
+    "docs": "typedoc src/index.ts src/cds-hooks/index.ts src/http/index.ts src/client/index.ts src/rest/index.ts --readme ./README.md",
     "lint": "eslint . --fix"
   },
   "keywords": [
@@ -23,6 +23,7 @@
   "author": "Automate Medical Inc.",
   "license": "Apache 2.0",
   "dependencies": {
+    "cross-fetch": "^3.1.4",
     "fastify": "^3.18.0"
   },
   "devDependencies": {

--- a/src/cds-hooks/index.test.ts
+++ b/src/cds-hooks/index.test.ts
@@ -197,9 +197,6 @@ test('A HookRequest satisfying all requirements should pass for the patient-view
 
   expect(response.statusCode).toEqual(200)
   expect(response.headers["content-type"]).toEqual("application/json; charset=utf-8")
-
-  console.log(response.body, body)
-
   expect(body).toEqual({"cards":[{"uuid":"0fe932e4-0e10-4ce4-b6a8-324ce858924d","detail":"This is a card","source":{"label":"CDS Services Inc"},"summary":"A summary of the findings","indicator":"info"}]})
 })
 

--- a/src/client/index.test.ts
+++ b/src/client/index.test.ts
@@ -1,0 +1,29 @@
+import Client from ".";
+
+test('Calling Capabilities returns a 200', async () => {
+  // @todo this test should use a mock, not the live 
+  const { capabilities } = Client("https://r4.smarthealthit.org", {})
+
+  const statement = await capabilities()
+  const body = await statement.json();
+
+  expect(statement.status).toEqual(200)
+  expect(body.resourceType).toEqual("CapabilityStatement")
+});
+
+test('Calling Patient query returns some', async () => {
+  // @todo this test should use a mock, not the live 
+  const { search, read } = Client("https://r4.smarthealthit.org", {})
+
+  const searchQuery = await search("Patient");
+  const searchResponse = await searchQuery.json() as fhir4.Bundle;
+
+  expect(searchQuery.status).toEqual(200)
+  expect(searchResponse.resourceType).toEqual("Bundle")
+
+  const patientQuery = await read("Patient", "87a339d0-8cae-418e-89c7-8651e6aab3c6");
+  const patientResponse = await patientQuery.json() as fhir4.Patient
+
+  expect(patientQuery.status).toEqual(200)
+  expect(patientResponse.resourceType).toEqual("Patient")
+});

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,6 +1,20 @@
 /**
  * @module client
- * @remarks Almost no-dependency TS FHIR client (we use cross fetch to give us a fetch instance)
+ * @beta
+ * 
+ * A Fetch-ful FHIR Client in TypeScript
+ * 
+ * @example Grab a capabilities statement:
+ * ```typescript
+ *  const { capabilities } = Client("https://r4.smarthealthit.org", {});
+ *  await capabilities().json() as fhir4.CapabilityStatement;
+ * ```
+ * 
+ * @example Easily read a Patient resource:
+ * ```typescript
+ *  const { read } = Client("https://r4.smarthealthit.org", {})
+ *  await read("Patient", "87a339d0-8cae-418e-89c7-8651e6aab3c6").json() as fhir4.Patient;
+ * ```
  */
 
 import fetch from "cross-fetch";
@@ -8,6 +22,9 @@ import fetch from "cross-fetch";
 type Summary = "true" | "false" | "text" | "count" | "data";
 
 export default function(baseUrl: string, init: RequestInit) {
+  /**
+   * Read the current state of the resource
+   */
   async function read(type: string, id: string, summary?: Summary) {
     return fetch(`${baseUrl}/${type}/${id}`, {
       method: "GET",
@@ -15,6 +32,9 @@ export default function(baseUrl: string, init: RequestInit) {
     });
   }
 
+  /**
+   * Read the state of a specific version of the resource
+   */
   async function vread(type: string, id: string, vid: string) {
     return fetch(`${baseUrl}/${type}/${id}/_history/${vid}`, {
       method: "GET",
@@ -22,6 +42,9 @@ export default function(baseUrl: string, init: RequestInit) {
     });
   }
   
+  /**
+   * Update an existing resource by its id (or create it if it is new)
+   */
   async function update(type: string, id: string, resource: fhir3.FhirResource | fhir4.FhirResource) {
     return fetch(`${baseUrl}/${type}/${id}`, {
       method: "PUT",
@@ -30,6 +53,9 @@ export default function(baseUrl: string, init: RequestInit) {
     });
   }
 
+  /**
+   * Update an existing resource by posting a set of changes to it
+   */
   async function patch(type: string, id: string, resource: fhir3.FhirResource | fhir4.FhirResource) {
     return fetch(`${baseUrl}/${type}/${id}`, {
       method: "PATCH",
@@ -38,6 +64,9 @@ export default function(baseUrl: string, init: RequestInit) {
     });
   }
 
+  /**
+   * Delete a resource
+   */
   async function destroy(type: string, id: string) {
     return fetch(`${baseUrl}/${type}/${id}`, {
       method: "DELETE",
@@ -46,6 +75,7 @@ export default function(baseUrl: string, init: RequestInit) {
   }
 
   /**
+   * Search the resource type based on some filter criteria OR Search across all resource types based on some filter criteria
    * @todo not complete
    */
   async function search(type: string) {
@@ -55,6 +85,9 @@ export default function(baseUrl: string, init: RequestInit) {
     });
   }
 
+  /**
+   * Create a new resource with a server assigned id
+   */
   async function create(type: string, id: string) {
     return fetch(`${baseUrl}/${type}`, {
       method: "POST",
@@ -62,10 +95,16 @@ export default function(baseUrl: string, init: RequestInit) {
     });
   }
 
+  /**
+   * Retrieve the change history for a particular resource type OR Retrieve the change history for all resources
+   */
   async function history() {
     throw new Error("Not Implemented");
   }
 
+  /**
+   * Get a capability statement for the system
+   */
   async function capabilities() {
     return fetch(`${baseUrl}/metadata`, {
       method: "GET",
@@ -73,6 +112,9 @@ export default function(baseUrl: string, init: RequestInit) {
     });
   }
 
+  /**
+   * Update, create or delete a set of resources in a single interaction
+   */
   async function batch(bundle: fhir3.Bundle | fhir4.Bundle) {
     return fetch(`${baseUrl}/`, {
       method: "POST",
@@ -81,6 +123,9 @@ export default function(baseUrl: string, init: RequestInit) {
     });
   }
 
+  /**
+   * Update, create or delete a set of resources in a single interaction
+   */
   async function transaction(bundle: fhir3.Bundle | fhir4.Bundle) {
     return fetch(`${baseUrl}/`, {
       method: "POST",

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,0 +1,105 @@
+/**
+ * @module client
+ * @remarks Almost no-dependency TS FHIR client (we use cross fetch to give us a fetch instance)
+ */
+
+import fetch from "cross-fetch";
+
+type Summary = "true" | "false" | "text" | "count" | "data";
+
+export default function(baseUrl: string, init: RequestInit) {
+  async function read(type: string, id: string, summary?: Summary) {
+    return fetch(`${baseUrl}/${type}/${id}`, {
+      method: "GET",
+      ...init
+    });
+  }
+
+  async function vread(type: string, id: string, vid: string) {
+    return fetch(`${baseUrl}/${type}/${id}/_history/${vid}`, {
+      method: "GET",
+      ...init
+    });
+  }
+  
+  async function update(type: string, id: string, resource: fhir3.FhirResource | fhir4.FhirResource) {
+    return fetch(`${baseUrl}/${type}/${id}`, {
+      method: "PUT",
+      body: JSON.stringify(resource),
+      ...init
+    });
+  }
+
+  async function patch(type: string, id: string, resource: fhir3.FhirResource | fhir4.FhirResource) {
+    return fetch(`${baseUrl}/${type}/${id}`, {
+      method: "PATCH",
+      body: JSON.stringify(resource),
+      ...init
+    });
+  }
+
+  async function destroy(type: string, id: string) {
+    return fetch(`${baseUrl}/${type}/${id}`, {
+      method: "DELETE",
+      ...init
+    });
+  }
+
+  /**
+   * @todo not complete
+   */
+  async function search(type: string) {
+    return fetch(`${baseUrl}/${type}`, {
+      method: "GET",
+      ...init
+    });
+  }
+
+  async function create(type: string, id: string) {
+    return fetch(`${baseUrl}/${type}`, {
+      method: "POST",
+      ...init
+    });
+  }
+
+  async function history() {
+    throw new Error("Not Implemented");
+  }
+
+  async function capabilities() {
+    return fetch(`${baseUrl}/metadata`, {
+      method: "GET",
+      ...init
+    });
+  }
+
+  async function batch(bundle: fhir3.Bundle | fhir4.Bundle) {
+    return fetch(`${baseUrl}/`, {
+      method: "POST",
+      body: JSON.stringify(bundle),
+      ...init
+    });
+  }
+
+  async function transaction(bundle: fhir3.Bundle | fhir4.Bundle) {
+    return fetch(`${baseUrl}/`, {
+      method: "POST",
+      body: JSON.stringify(bundle),
+      ...init
+    });
+  }
+
+  return {
+    read,
+    vread,
+    update,
+    patch,
+    destroy,
+    search,
+    create,
+    history,
+    capabilities,
+    batch,
+    transaction
+  }
+}


### PR DESCRIPTION
I wrote a FHIR client that is a simple wrapper around fetch.

This is helpful because it's a minimal library that can work in any JavaScript environment (getting a cross-platform/isomorphic HTTP client API working is actually kind of hard tbh)

Anyways, this turned out to be way simpler than expected and includes some real production tests

It, sadly, does add one production dependency

The test case shows how to use it, but basically it exposes the common operations like `read`, `search` for all FHIR resources a server has (like `Patient` or `Encounter` or etc) - the result is a JSON object of the resource. With the TypeScript definitions its possible to hint at the contents of the data too.