### PR TITLE
Async Support for the ServiceHandler on CDS Service

### DIFF
--- a/src/cds-hooks/routes.ts
+++ b/src/cds-hooks/routes.ts
@@ -26,7 +26,7 @@ function addCorsHeaders(reply: FastifyReply): void {
  * @param options -
  */
 function invoke(options: Config["cdsHooks"]) {
-  return (request: FastifyRequest<{ Params: { id: string }}>, reply: FastifyReply) => {
+  return async (request: FastifyRequest<{ Params: { id: string }}>, reply: FastifyReply) => {
     if (options?.cors) addCorsHeaders(reply);
     const service = getService(options?.services || [], request.params.id);
 
@@ -47,7 +47,7 @@ function invoke(options: Config["cdsHooks"]) {
         reply.code(400).send(validationError)
       // 4. Otherwise execute the service
       } else {
-        const response = service.handler(hookRequest);
+        const response = await service.handler(hookRequest);
         reply.send(response);
       }
     }

--- a/src/cds-hooks/service.ts
+++ b/src/cds-hooks/service.ts
@@ -7,10 +7,9 @@ import { Hooks } from ".";
  *
  * @todo Is it possible to structure the generic here on something other than
  * `any`?
- * @todo async?
  */
 type ServiceHandler = {
-  (request: CDSHooks.HookRequest<any>): CDSHooks.HookResponse;
+  (request: CDSHooks.HookRequest<any>): Promise<CDSHooks.HookResponse> | CDSHooks.HookResponse;
 };
 
 /**


### PR DESCRIPTION
You can return an `async` tagged function/Promise in the "ServiceHandler" function we define to respond when a Service is invoked by a HookRequest