### PR TITLE
Node 12.7+ package export resolution settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,11 @@
   ],
   "author": "Automate Medical Inc.",
   "license": "Apache 2.0",
+  "exports": {
+    "./cds-hooks": "./dist/cds-hooks/index.js",
+    "./http": "./dist/http/index.js",
+    "./rest": "./dist/rest/index.js"
+  },
   "dependencies": {
     "@reduxjs/toolkit": "^1.6.0",
     "cross-fetch": "^3.1.4",


### PR DESCRIPTION
- Allows for importing from @sero.run/sero/cds-hooks etc now
- Closes #41 