### PR TITLE
Enforce Node v14.17 as minimum required version

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,5 +46,8 @@
     "ts-node": "^10.0.0",
     "typedoc": "^0.21.2",
     "typescript": "^4.3.4"
+  },
+  "engines": {
+    "node": ">=14.17"
   }
 }


### PR DESCRIPTION
As discussed in https://github.com/Automate-Medical/sero/issues/44, we can use the ["engines"](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#engines) field in `package.json` to specify that Node v14.17.x is the minimum required version for the project. 