### PR TITLE
Change indicator type in card class constructor

### DIFF
--- a/src/cds-hooks/card.ts
+++ b/src/cds-hooks/card.ts
@@ -93,7 +93,7 @@ export default class Card implements CDSHooks.Card {
    */
   links?: CDSHooks.Link[];
 
-  constructor(options: Partial<CDSHooks.Card> & { source: CDSHooks.Source; summary: string; indicator: 'info' } ) {
+  constructor(options: Partial<CDSHooks.Card> & { source: CDSHooks.Source; summary: string; indicator: 'info' | 'warning' | 'critical' } ) {
     this.uuid = options.uuid || randomUUID();
     this.detail = options.detail;
     this.suggestions = options.suggestions as Suggestion[];


### PR DESCRIPTION
The indicator type is overwritten in the card class constructor. This change lets cards change urgency to `warning` and `critical` types. 