### PR TITLE
DaVinci CRD CDS Hooks example/service

### DIFF
--- a/example/cds-hooks/better-patient-view.ts
+++ b/example/cds-hooks/better-patient-view.ts
@@ -1,4 +1,5 @@
-import { Service, Card } from "../../src/cds-hooks";
+import { Service, Card, HookRequest } from "../../src/cds-hooks";
+import { Hooks } from "../../src/cds-hooks/util";
 import {
   processAddresses,
   processPatientNames,
@@ -34,7 +35,7 @@ export default new Service(
   {
     id: "9",
     title: "Patient view with last encounter",
-    hook: "patient-view",
+    hook: "patient-view" as Hooks,
     description:
       "A patient-view hook with patient and encounter prefetch template values. presents patient info and last encounter information",
     prefetch: {
@@ -43,7 +44,7 @@ export default new Service(
     },
   },
   (
-    request: CDSHooks.HookRequest<{
+    request: HookRequest<{
       patient: fhir4.Patient;
       encounter: fhir4.Bundle;
     }>

--- a/example/current-time/get-current-time.ts
+++ b/example/current-time/get-current-time.ts
@@ -1,4 +1,5 @@
-import { Service, Card, Hooks } from "../../src/cds-hooks";
+import { Service, Card } from "../../src/cds-hooks";
+import { Hooks } from "../../src/cds-hooks/util";
 
 const options = {
   id: "get-current-time",

--- a/src/cds-hooks/service.ts
+++ b/src/cds-hooks/service.ts
@@ -90,9 +90,9 @@ export default class Service implements Service {
   /**
    * An object containing key/value pairs of FHIR extensions. The key is the name
    * of the extension and the value is the extended data made available to the CDS
-   * service. Extensions are loosely defined, as Incorporating all valid
+   * service. Extensions are loosely defined, as incorporating all valid
    * requirements would make this specification very cumbersome and difficult to
-   * implement. Thus, all additional information a service needs will be implemented
+   * implement. Thus, all the additional information a service needs will be implemented
    * as an extension. 
    */
   public extension?: Extension;

--- a/src/cds-hooks/service.ts
+++ b/src/cds-hooks/service.ts
@@ -153,7 +153,7 @@ interface PrefetchTemplate {
  * See: https://www.hl7.org/fhir/extensibility.html
  */
 interface Extension {
-  [key: string]: string;
+  [key: string]: any;
 }
 
 interface HookRequestWithFhir<T> extends HookRequestBasic<T> {

--- a/src/cds-hooks/service.ts
+++ b/src/cds-hooks/service.ts
@@ -87,6 +87,15 @@ export default class Service implements Service {
    * A function to execute on HookRequest invocation events
    */
   public handler: ServiceHandler;
+  /**
+   * An object containing key/value pairs of FHIR extensions. The key is the name
+   * of the extension and the value is the extended data made available to the CDS
+   * service. Extensions are loosely defined, as Incorporating all valid
+   * requirements would make this specification very cumbersome and difficult to
+   * implement. Thus, all additional information a service needs will be implemented
+   * as an extension. 
+   */
+  public extensions?: Extensions;
 
   /**
    * Pass any options along with a function that will execute on HookRequest
@@ -102,6 +111,7 @@ export default class Service implements Service {
     this.hook = options.hook;
     this.description = options.description;
     this.prefetch = options.prefetch;
+    this.extensions = options.extensions;
     this.title = options.title;
     this.id = options.id || randomUUID();
     this.handler = handler;
@@ -116,14 +126,14 @@ export interface HookResponse {
    * how to display cards, but this specification recommends displaying
    * suggestions using buttons, and links using underlined text.
    */
-  cards?: Card[]
+  cards?: Card[];
 
   /**
    * An array of actions that the CDS Service proposes to auto-apply. Each
    * action follows the schema of a card-based suggestion.action. The CDS
    * Client decides whether to auto-apply actions.
    */
-  systemActions?: SystemAction[]
+  systemActions?: SystemAction[];
 }
 
 /**
@@ -132,7 +142,18 @@ export interface HookResponse {
  * https://cds-hooks.org/specification/current/#prefetch-template
  */
 interface PrefetchTemplate {
-  [key: string]: string
+  [key: string]: string;
+}
+
+/**
+ * An extension is an additional information exchange specification based on
+ * common requirements across healthcare. FHIR expects that additional requirements
+ * are implemented as extensions.
+ * See: https://cds-hooks.org/specification/current/#extensions
+ * See: https://www.hl7.org/fhir/extensibility.html
+ */
+interface Extensions {
+  [key: string]: string;
 }
 
 interface HookRequestWithFhir<T> extends HookRequestBasic<T> {
@@ -140,14 +161,14 @@ interface HookRequestWithFhir<T> extends HookRequestBasic<T> {
    * The base URL of the CDS Client's FHIR server. If fhirAuthorization is
    * provided, this field is REQUIRED. The scheme should be https
    */
-  fhirServer: string
+  fhirServer: string;
 
   /**
    * A structure holding an OAuth 2.0 bearer access token granting the CDS
    * Service access to FHIR resources, along with supplemental information
    * relating to the token.
    */
-  fhirAuthorization: FhirAuthorization
+  fhirAuthorization: FhirAuthorization;
 }
 
 interface HookRequestBasic<T> {
@@ -155,24 +176,24 @@ interface HookRequestBasic<T> {
    * The hook that triggered this CDS Service call. See:
    * https://cds-hooks.org/specification/current/#hooks
    */
-  hook: string
+  hook: string;
 
   /**
    * A universally unique identifier (UUID) for this particular hook call.
    */
-  hookInstance: string
+  hookInstance: string;
 
   /**
    * Hook-specific contextual data that the CDS service will need. For example,
    * with the patient-view hook this will include the FHIR identifier of the
    * Patient being viewed. For details, see the Hooks specification page.
    */
-  context: any
+  context: any;
 
   /**
    * The FHIR data that was prefetched by the CDS Client
    */
-  prefetch: T
+  prefetch: T;
 }
 
-export type HookRequest<T> = HookRequestBasic<T> | HookRequestWithFhir<T>
+export type HookRequest<T> = HookRequestBasic<T> | HookRequestWithFhir<T>;

--- a/src/cds-hooks/service.ts
+++ b/src/cds-hooks/service.ts
@@ -95,7 +95,7 @@ export default class Service implements Service {
    * implement. Thus, all additional information a service needs will be implemented
    * as an extension. 
    */
-  public extensions?: Extensions;
+  public extension?: Extension;
 
   /**
    * Pass any options along with a function that will execute on HookRequest
@@ -111,7 +111,7 @@ export default class Service implements Service {
     this.hook = options.hook;
     this.description = options.description;
     this.prefetch = options.prefetch;
-    this.extensions = options.extensions;
+    this.extension = options.extension;
     this.title = options.title;
     this.id = options.id || randomUUID();
     this.handler = handler;
@@ -152,7 +152,7 @@ interface PrefetchTemplate {
  * See: https://cds-hooks.org/specification/current/#extensions
  * See: https://www.hl7.org/fhir/extensibility.html
  */
-interface Extensions {
+interface Extension {
   [key: string]: string;
 }
 


### PR DESCRIPTION
A draft pull request that moves towards a working example of the DaVinci CRD, seen in #12. 

The first thing this does is add support for the extensions key. According to the spec:

> ...rather than proposing a change to the base CDS Hook specification, this IG leverages the CDS Hook extension mechanism to
provide an experimental approach to specify and control the types of information returned to users.

This is what a CRD service config options using Sero could look like (shortened for brevity):

```
const options = {
  hook: "order-select",
  title: "Payer XYZ Order Selection Requirements",
  description:
    "Indicates coverage requirements associated with draft orders, including expectations for prior authorization, recommended therapy alternatives, etc.",
  id: "order-select-crd",
  prefetch: {
    patient: "Patient/{{context.patientId}}",
    medications: "MedicationOrder?patient={{context.patientId}}",
  },
  extension: {
    "davinci-crd.configuration-options": [
      {
        code: "priorauth",
        type: "boolean",
        name: "Prior authorization",
        description:
          "Provides indications of whether prior authorization is required for the proposed order",
        default: true,
      },
      {
        code: "prior-auth-form",
        type: "boolean",
        name: "Prior Authorization Forms",
        description:
          "Indicates any forms that should be completed as part of a prior authorization process",
        default: true,
      },
      ...
    ],
  },
};
```
To do this, Sero needs to support `extensions`, which means extending the `Service` class. More on this [here](https://cds-hooks.org/specification/current/#extensions). 

According to the spec, the value of an extension must be a pre-coordinated JSON object. In the object, The key is the name of the extension and the value is the extended data made available to the CDS service. Extensions are loosely defined, as incorporating all valid requirements would make this specification very cumbersome and difficult to implement. Thus, all additional information a service needs will be implemented as an extension. 

This is not a working example yet but publishing this to master means the sero npm package can support it and examples can be made in isolation. 