### PR TITLE
Support searchType operation in Client

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@sero.run/sero",
   "version": "0.0.14",
   "description": "Sero is a modular TypeScript toolchain for FHIR (and friends) sponsored by Automate Medical Inc.",
-  "homepage": "https://sero.run",
+  "homepage": "https://docs.sero.run",
   "bugs": "https://github.com/automate-medical/sero/issues",
   "scripts": {
     "format": "prettier --write \"src/**/*.ts\"",
@@ -48,6 +48,10 @@
     "./rest/index": {
       "import": "./dist/esm/rest/index.js",
       "require": "./dist/cjs/rest/index.js"
+    },
+    "./client/index": {
+      "import": "./dist/esm/client/index.js",
+      "require": "./dist/cjs/client/index.js"
     }
   },
   "files": [

--- a/src/cds-hooks/index.ts
+++ b/src/cds-hooks/index.ts
@@ -1,5 +1,5 @@
 /**
- * @module @sero.run/sero/cds-hooks
+ * @module cds-hooks
  */
 
 export { default as mount } from "./routes.js";

--- a/src/client/index.test.ts
+++ b/src/client/index.test.ts
@@ -2,7 +2,7 @@ import Client from ".";
 
 test('Calling Capabilities returns a 200', async () => {
   // @todo this test should use a mock, not the live
-  const { capabilities } = Client("https://r4.smarthealthit.org", {})
+  const { capabilities } = Client("https://r4.smarthealthit.org")
 
   const statement = await capabilities()
   const body = await statement.json();
@@ -13,13 +13,12 @@ test('Calling Capabilities returns a 200', async () => {
 
 test('Calling Patient query returns some', async () => {
   // @todo this test should use a mock, not the live
-  const { searchType, read } = Client("https://r4.smarthealthit.org", {})
+  const { searchType, read } = Client("https://r4.smarthealthit.org")
 
-  const searchQuery = await searchType("Patient");
-  const searchResponse = await searchQuery.json() as fhir4.Bundle;
+  const searchQuery = searchType("Patient");
+  const searchResponse = await searchQuery.next()
 
-  expect(searchQuery.status).toEqual(200)
-  expect(searchResponse.resourceType).toEqual("Bundle")
+  expect(searchResponse.value?.resourceType).toEqual("Bundle")
 
   const patientQuery = await read("Patient", "87a339d0-8cae-418e-89c7-8651e6aab3c6");
   const patientResponse = await patientQuery.json() as fhir4.Patient

--- a/src/client/index.test.ts
+++ b/src/client/index.test.ts
@@ -18,11 +18,26 @@ test('Calling Patient query returns some', async () => {
   const searchQuery = searchType("Patient");
   const searchResponse = await searchQuery.next()
 
-  expect(searchResponse.value?.resourceType).toEqual("Bundle")
+  let resourceType = searchResponse.value?.resourceType
+  expect(resourceType).toEqual("Bundle")
 
   const patientQuery = await read("Patient", "87a339d0-8cae-418e-89c7-8651e6aab3c6");
   const patientResponse = await patientQuery.json() as fhir4.Patient
 
   expect(patientQuery.status).toEqual(200)
   expect(patientResponse.resourceType).toEqual("Patient")
+});
+
+test('searchType returns pagination', async () => {
+  // @todo this test should use a mock, not the live
+  const { searchType } = Client("https://r4.smarthealthit.org")
+
+  const searchQuery = searchType("Patient");
+  await searchQuery.next();
+  await searchQuery.next();
+  await searchQuery.next();
+
+  const testCall = await searchQuery.next();
+  
+  expect(testCall.done).toEqual(false);
 });

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -6,28 +6,37 @@
  *
  * @example Grab a capabilities statement:
  * ```typescript
- *  const { capabilities } = Client("https://r4.smarthealthit.org", {});
+ *  const { capabilities } = Client("https://r4.smarthealthit.org");
  *  await capabilities().json() as fhir4.CapabilityStatement;
  * ```
  *
  * @example Easily read a Patient resource:
  * ```typescript
- *  const { read } = Client("https://r4.smarthealthit.org", {})
+ *  const { read } = Client("https://r4.smarthealthit.org")
  *  await read("Patient", "87a339d0-8cae-418e-89c7-8651e6aab3c6").json() as fhir4.Patient;
  * ```
+ * 
+ * @example Iterables returned for the searchType operation:
+ * ```typescript
+ *  const { searchType } = Client("https://r4.smarthealthit.org")
+ *  const search = searchType("Patient");
+ *  search.next(); 
+ * ```
+ * 
+ * @todo update client to use FhirResource string type union when it is available in @types/fhir
  */
 
 import fetch from "cross-fetch";
 
 type Summary = "true" | "false" | "text" | "count" | "data";
 
-export default function(baseUrl: string, init: RequestInit): {
+export default function(baseUrl: string, init: RequestInit = {}): {
   read: { (type: string, id: string, summary?: Summary): Promise<Response> };
   vread: { (type: string, id: string, vid: string): Promise<Response> };
   update: { (type: string, id: string, resource: fhir4.FhirResource): Promise<Response> };
   patch: { (type: string, id: string, resource: fhir4.FhirResource ): Promise<Response> };
   destroy: { (type: string, id: string): Promise<Response> };
-  searchType: { (type: string): Promise<Response> };
+  searchType: { (type: string): AsyncGenerator<fhir4.Bundle, void, any> };
   create: { (type: string): Promise<Response> };
   historyType: any;
   historyInstance: any;
@@ -89,13 +98,11 @@ export default function(baseUrl: string, init: RequestInit): {
 
   /**
    * Search the resource type based on some filter criteria OR Search across all resource types based on some filter criteria
-   * @todo not complete
+   * @todo add parameters
+   * @todo has a max call stack bug for large page counts
    */
-  async function searchType(type: string) {
-    return fetch(`${baseUrl}/${type}`, {
-      method: "GET",
-      ...init
-    });
+  async function* searchType(type: string) {  
+    return yield * paginated(`${baseUrl}/${type}`, init);
   }
 
   /**
@@ -167,5 +174,21 @@ export default function(baseUrl: string, init: RequestInit): {
     capabilities,
     batch,
     transaction
+  }
+}
+
+async function* paginated(endpoint: string, init: RequestInit = {}): AsyncGenerator<fhir4.Bundle, void, any> {
+  const response = await fetch(endpoint, init);
+
+  if (!response.ok) throw new Error(await response.text());
+
+  const page = await response.json() as fhir4.Bundle;
+
+  yield page; 
+
+  const nextLink = page.link?.find((link) => link.relation === 'next');
+
+  if (nextLink?.url) {
+    yield * paginated(nextLink.url);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,3 +24,5 @@ export {
   default as Http,
   start
 } from "./http/index.js";
+
+export { default as Client } from "./client/index.js"


### PR DESCRIPTION
- Also exposes Client to the package exports
- Uses generators/iterators to handle pagination

To use, you can do things like:

```typescript
const { searchType } = Client("https://fhir.humana.com/api")
const search = searchType("InsurancePlan")
search.next(); // Next will return an iteration/page until there are none left
```

Or:


```typescript
const { searchType } = Client("https://fhir.humana.com/api")
for await (const page of searchType("InsurancePlan")) {
  console.log(page) // This async for loop will call console.log on every page until it's finished
}
```

More at: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators

AFAIK, this is the first JS FHIR Client to use Iterators

It doesn't handle the "OperationOutcome" failure case - but that's fine