### PR TITLE
fix: add correct tsconfig path to "docs" script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "format": "prettier --write \"src/**/*.ts\"",
     "test": "jest --detectOpenHandles",
-    "docs": "typedoc src/index.ts src/cds-hooks/index.ts src/rest/index.ts --readme ./README.md",
+    "docs": "typedoc src/index.ts src/cds-hooks/index.ts src/rest/index.ts --readme ./README.md --tsconfig tsconfig/base.json",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "build": "run-s build:*",


### PR DESCRIPTION
When on `master`, executing `npm run docs` gets:

```
Warning: No compiler options set. This likely means that TypeDoc did not find your tsconfig.json. Generated documentation will probably be empty.
Warning: Unable to locate entry point: /Users/jmc/automate-medical/sero/src/index.ts
Warning: Unable to locate entry point: /Users/jmc/automate-medical/sero/src/cds-hooks/index.ts
Warning: Unable to locate entry point: /Users/jmc/automate-medical/sero/src/rest/index.ts
```

If I edit the docs script in package.json to have the option "--tsconfig tsconfig/base.json" (see https://typedoc.org/guides/options/#tsconfig), then `npm run docs` executes with no warnings and renders the docs.