### PR TITLE
Changing redirectHost and redirectUrl in the SMART auth module

### DIFF
--- a/src/smart-auth/index.test.ts
+++ b/src/smart-auth/index.test.ts
@@ -19,7 +19,7 @@ test("an authorize url correctly redirects to the configured tokenHost", async (
     url: `/smart/idp/auth`
   })
 
- expect(response.headers['location']).toBe("http://external.localhost/oauth/authorize?response_type=code&client_id=123&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fsmart%2Fidp%2Fredirect&scope=launch&state=smart-auth-static-bytes-not-random-mock")
+ expect(response.headers['location']).toBe("http://external.localhost/oauth/authorize?response_type=code&client_id=123&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fsmart%2Fidp%2Fredirect&scope=launch&state=smart-auth-static-bytes-not-random-mock")
 })
 
 // @todo this requires implementing a mocked oauth server response

--- a/src/smart-auth/index.ts
+++ b/src/smart-auth/index.ts
@@ -16,8 +16,8 @@ export interface SmartAuthProvider {
   name: string;
   scope: string[]; // @todo this could be typed to the FHIR spec
   credentials: SmartAuthCredentials;
-  redirectPath?: string;
-  redirectUri?: string;
+  redirectHost: string;
+  redirectPath?: string; 
   authorizePath?: string;
   authorizeParams?: Object; // @todo
   prefix?: string;
@@ -66,13 +66,13 @@ function checkState(state: string) {
 }
 
 const oauthPlugin: FastifyPluginCallback<SmartAuthProvider> = function (http, options, next) {
-  const { name, credentials, scope } = options
+  const { name, credentials, scope, redirectHost } = options
 
   const prefix = options.prefix = "/smart";
   const authorizeParams = options.authorizeParams || {}
   const authorizePath = options.authorizePath || `${prefix}/${name.toLowerCase()}/auth`
   const redirectPath = options.redirectPath || `${prefix}/${name.toLowerCase()}/redirect`
-  const redirectUri = options.redirectUri || `http://localhost:8080${redirectPath}`
+  const redirectUri = `${redirectHost}${redirectPath}`
 
   function generateAuthorizationUri() {
     const state = generateState();

--- a/test/smart-auth/idp.ts
+++ b/test/smart-auth/idp.ts
@@ -3,6 +3,7 @@ import { SmartAuthProvider } from "../../src";
 const smartAuthProviderExample: SmartAuthProvider = {
   name: "idp",
   scope: ["launch"],
+  redirectHost: "http://localhost:3000/smart/provider/redirect",
   credentials: {
     client: {
       id: "123",

--- a/test/smart-auth/idp.ts
+++ b/test/smart-auth/idp.ts
@@ -3,7 +3,7 @@ import { SmartAuthProvider } from "../../src";
 const smartAuthProviderExample: SmartAuthProvider = {
   name: "idp",
   scope: ["launch"],
-  redirectHost: "http://localhost:3000/smart/provider/redirect",
+  redirectHost: "http://localhost:3000",
   credentials: {
     client: {
       id: "123",


### PR DESCRIPTION
Addresses the comments in #92, which changes the `redirectHost` property of the SmartAuthProvider to be mandatory, and changes the value of the reditectUrl.

(this is the same issue as #93, but without the long commit history from a master branch that had a local commit history).