### PR TITLE
Refactor SmartAuthProvider

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,6 @@ export {
 
 export {
   default as SmartAuth,
-  SmartAuthCredentials,
   SmartAuthProvider,
   SmartAuthNamespace,
   SmartAuthRedirectQuerystringSchema,

--- a/src/smart-auth/index.test.ts
+++ b/src/smart-auth/index.test.ts
@@ -10,7 +10,7 @@ test("an authorize url short path helper is built from the ID of the SmartProvid
     url: `/smart/idp/auth`
   })
 
- expect(response.statusCode).toBe(302)
+  expect(response.statusCode).toBe(302)
 })
 
 test("an authorize url correctly redirects to the configured tokenHost", async () => {
@@ -19,7 +19,7 @@ test("an authorize url correctly redirects to the configured tokenHost", async (
     url: `/smart/idp/auth`
   })
 
- expect(response.headers['location']).toBe("http://external.localhost/oauth/authorize?response_type=code&client_id=123&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fsmart%2Fidp%2Fredirect&scope=launch&state=smart-auth-static-bytes-not-random-mock")
+  expect(response.headers['location']).toBe("http://external.localhost/oauth/authorize?response_type=code&client_id=123&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fsmart%2Fidp%2Fredirect&scope=launch&state=smart-auth-static-bytes-not-random-mock")
 })
 
 // @todo this requires implementing a mocked oauth server response

--- a/test/smart-auth/idp.ts
+++ b/test/smart-auth/idp.ts
@@ -3,16 +3,15 @@ import { SmartAuthProvider } from "../../src";
 const smartAuthProviderExample: SmartAuthProvider = {
   name: "idp",
   scope: ["launch"],
-  redirectHost: "http://localhost:3000",
-  credentials: {
-    client: {
-      id: "123",
-      secret: "somesecret"
-    },
-    auth: {
-      tokenHost: "http://external.localhost/smart/idp/token"
-    }
-  }
+  client: {
+    id: "123",
+    secret: "somesecret"
+  },
+  auth: {},
+  redirect: {
+    host: "http://localhost:3000"
+  },
+  iss: "http://external.localhost/smart/"
 }
 
 export default smartAuthProviderExample;


### PR DESCRIPTION
* Removes SmartAuthCredentials type
* Adds new `iss` property - this is used as base URL constructor, tokenHost was awkward
* Attempts to unify/rework the client/auth/credentials keyword in the SmartAuthProvider type
* Also added utility-types because it has great TypeScript utility types (including one I use)