### PR TITLE
Changing tokenHost in auth config object to be required

### DIFF
--- a/src/client/index.test.ts
+++ b/src/client/index.test.ts
@@ -1,5 +1,4 @@
 import Client from ".";
-import { fastify as app } from "../../test/fixtures/authServer"
 
 test('Calling Capabilities returns a 200', async () => {
   // @todo this test should use a mock, not the live
@@ -10,7 +9,6 @@ test('Calling Capabilities returns a 200', async () => {
 
   expect(statement.status).toEqual(200)
   expect(body.resourceType).toEqual("CapabilityStatement")
-  app.close();
 });
 
 test('Calling Patient query returns some', async () => {
@@ -30,7 +28,6 @@ test('Calling Patient query returns some', async () => {
 
   // expect(patientQuery.status).toEqual(200)
   expect(patientQuery.resourceType).toEqual("Patient")
-  app.close();
 });
 
 test('search returns pagination', async () => {
@@ -45,5 +42,4 @@ test('search returns pagination', async () => {
   const testCall = await searchQuery.next();
   
   expect(testCall.done).toEqual(false);
-  app.close();
 });

--- a/src/client/index.test.ts
+++ b/src/client/index.test.ts
@@ -1,4 +1,5 @@
 import Client from ".";
+import { fastify as app } from "../../test/fixtures/authServer"
 
 test('Calling Capabilities returns a 200', async () => {
   // @todo this test should use a mock, not the live
@@ -9,6 +10,7 @@ test('Calling Capabilities returns a 200', async () => {
 
   expect(statement.status).toEqual(200)
   expect(body.resourceType).toEqual("CapabilityStatement")
+  app.close();
 });
 
 test('Calling Patient query returns some', async () => {
@@ -28,6 +30,7 @@ test('Calling Patient query returns some', async () => {
 
   // expect(patientQuery.status).toEqual(200)
   expect(patientQuery.resourceType).toEqual("Patient")
+  app.close();
 });
 
 test('search returns pagination', async () => {
@@ -42,4 +45,5 @@ test('search returns pagination', async () => {
   const testCall = await searchQuery.next();
   
   expect(testCall.done).toEqual(false);
+  app.close();
 });

--- a/src/smart-auth/README.md
+++ b/src/smart-auth/README.md
@@ -30,18 +30,22 @@ import Fastify from "fastify";
 const fastify = Fastify();
 
 // Our Smart Health ID Provider config
-const smartHealthIdConfig: SmartAuthProvider = {
-  name: "smartHealthIdProvider",
+const smartAuthProviderExample: SmartAuthProvider = {
+  name: "idp",
   scope: ["launch"],
   client: {
     id: "123",
-    secret: "somesecret"
+    secret: "somesecret",
+  },
+  auth: {
+    tokenHost: "http://external.localhost/",
+    authorizePath: "/test/oauth/authorize",
   },
   redirect: {
-    host: "http://localhost:3000"
+    host: "http://localhost:3000",
   },
-  iss: "http://external.localhost/smart/"
-}
+  iss: "http://external.localhost/",
+};
 
 // Initialize the plugin with our Smart Health ID Provider config
 fastify.register(SmartAuth, smartHealthIdConfig)
@@ -167,7 +171,7 @@ export type SmartAuthProvider = {
     /** Optional params to append to the authorization redirect */
     authorizeParams?: Record<string, any>;
     /** String used to set the host to request the tokens to. Required. */
-    tokenHost?: string;
+    tokenHost: string;
     /** String path to request an access token. Default to /oauth/token. */
     tokenPath?: string;
     /** String path to revoke an access token. Default to /oauth/revoke. */

--- a/src/smart-auth/README.md
+++ b/src/smart-auth/README.md
@@ -38,13 +38,13 @@ const smartAuthProviderExample: SmartAuthProvider = {
     secret: "somesecret",
   },
   auth: {
-    tokenHost: "http://external.localhost/",
+    tokenHost: "http://external.localhost",
     authorizePath: "/smart/oauth/authorize",
   },
   redirect: {
     host: "http://localhost:3000",
   },
-  iss: "http://external.localhost/",
+  iss: "http://external.localhost/issuer",
 };
 
 // Initialize the plugin with our Smart Health ID Provider config

--- a/src/smart-auth/README.md
+++ b/src/smart-auth/README.md
@@ -39,7 +39,7 @@ const smartAuthProviderExample: SmartAuthProvider = {
   },
   auth: {
     tokenHost: "http://external.localhost/",
-    authorizePath: "/test/oauth/authorize",
+    authorizePath: "/smart/oauth/authorize",
   },
   redirect: {
     host: "http://localhost:3000",

--- a/src/smart-auth/index.test.ts
+++ b/src/smart-auth/index.test.ts
@@ -11,6 +11,7 @@ test("an authorize url short path helper is built from the ID of the SmartProvid
   })
 
   expect(response.statusCode).toBe(302)
+  app.close();
 })
 
 test("an authorize url correctly redirects to the configured tokenHost", async () => {
@@ -20,6 +21,7 @@ test("an authorize url correctly redirects to the configured tokenHost", async (
   })
 
   expect(response.headers['location']).toBe("http://external.localhost/oauth/authorize?response_type=code&client_id=123&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fsmart%2Fidp%2Fredirect&scope=launch&state=smart-auth-static-bytes-not-random-mock")
+  app.close();
 })
 
 // @todo this requires implementing a mocked oauth server response

--- a/src/smart-auth/index.test.ts
+++ b/src/smart-auth/index.test.ts
@@ -20,17 +20,6 @@ test("an authorize url correctly redirects to the configured tokenHost", async (
   });
 
   expect(response.headers["location"]).toBe(
-    "http://external.localhost/oauth/authorize?response_type=code&client_id=123&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fsmart%2Fidp%2Fredirect&scope=launch&state=smart-auth-static-bytes-not-random-mock"
-  );
-});
-
-test("a slash is included in the url - this should re-direct us to th", async () => {
-  const response = await app.inject({
-    method: "GET",
-    url: "/smart/idp/auth",
-  });
-
-  expect(response.headers["location"]).toBe(
     "http://external.localhost/test/oauth/authorize?response_type=code&client_id=123&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fsmart%2Fidp%2Fredirect&scope=launch&state=smart-auth-static-bytes-not-random-mock"
   );
 });

--- a/src/smart-auth/index.test.ts
+++ b/src/smart-auth/index.test.ts
@@ -1,31 +1,29 @@
-import { fastify as app } from "../../test/fixtures/authServer";
+import { fastify as app } from "../../test/fixtures/authServer"
 
-jest.mock("crypto", () => ({
-  randomBytes: (_number: number) => "smart-auth-static-bytes-not-random-mock",
+jest.mock('crypto', () => ({
+  randomBytes: (_number: number) => "smart-auth-static-bytes-not-random-mock"
 }));
 
 test("an authorize url short path helper is built from the ID of the SmartProviderAuth", async () => {
   const response = await app.inject({
-    method: "GET",
-    url: `/smart/idp/auth`,
-  });
+    method: 'GET',
+    url: `/smart/idp/auth`
+  })
 
-  expect(response.statusCode).toBe(302);
-});
+  expect(response.statusCode).toBe(302)
+})
 
 test("an authorize url correctly redirects to the configured tokenHost", async () => {
   const response = await app.inject({
-    method: "GET",
-    url: `/smart/idp/auth`,
-  });
+    method: 'GET',
+    url: `/smart/idp/auth`
+  })
 
-  expect(response.headers["location"]).toBe(
-    "http://external.localhost/test/oauth/authorize?response_type=code&client_id=123&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fsmart%2Fidp%2Fredirect&scope=launch&state=smart-auth-static-bytes-not-random-mock"
-  );
-});
+  expect(response.headers['location']).toBe("http://external.localhost/test/oauth/authorize?response_type=code&client_id=123&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fsmart%2Fidp%2Fredirect&scope=launch&state=smart-auth-static-bytes-not-random-mock")
+})
 
 // @todo this requires implementing a mocked oauth server response
-test.todo("a callback url (in the server fixture) is successfully callable");
+test.todo("a callback url (in the server fixture) is successfully callable") 
 //, async () => {
 //   const response = await app.inject({
 //     method: 'GET',

--- a/src/smart-auth/index.test.ts
+++ b/src/smart-auth/index.test.ts
@@ -19,7 +19,7 @@ test("an authorize url correctly redirects to the configured tokenHost", async (
     url: `/smart/idp/auth`
   })
 
-  expect(response.headers['location']).toBe("http://external.localhost/test/oauth/authorize?response_type=code&client_id=123&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fsmart%2Fidp%2Fredirect&scope=launch&state=smart-auth-static-bytes-not-random-mock")
+  expect(response.headers['location']).toBe("http://external.localhost/smart/oauth/authorize?response_type=code&client_id=123&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fsmart%2Fidp%2Fredirect&scope=launch&state=smart-auth-static-bytes-not-random-mock")
 })
 
 // @todo this requires implementing a mocked oauth server response

--- a/src/smart-auth/index.test.ts
+++ b/src/smart-auth/index.test.ts
@@ -1,31 +1,42 @@
-import { fastify as app } from "../../test/fixtures/authServer"
+import { fastify as app } from "../../test/fixtures/authServer";
 
-jest.mock('crypto', () => ({
-  randomBytes: (_number: number) => "smart-auth-static-bytes-not-random-mock"
+jest.mock("crypto", () => ({
+  randomBytes: (_number: number) => "smart-auth-static-bytes-not-random-mock",
 }));
 
 test("an authorize url short path helper is built from the ID of the SmartProviderAuth", async () => {
   const response = await app.inject({
-    method: 'GET',
-    url: `/smart/idp/auth`
-  })
+    method: "GET",
+    url: `/smart/idp/auth`,
+  });
 
-  expect(response.statusCode).toBe(302)
-  app.close();
-})
+  expect(response.statusCode).toBe(302);
+});
 
 test("an authorize url correctly redirects to the configured tokenHost", async () => {
   const response = await app.inject({
-    method: 'GET',
-    url: `/smart/idp/auth`
-  })
+    method: "GET",
+    url: `/smart/idp/auth`,
+  });
 
-  expect(response.headers['location']).toBe("http://external.localhost/oauth/authorize?response_type=code&client_id=123&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fsmart%2Fidp%2Fredirect&scope=launch&state=smart-auth-static-bytes-not-random-mock")
-  app.close();
-})
+  expect(response.headers["location"]).toBe(
+    "http://external.localhost/oauth/authorize?response_type=code&client_id=123&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fsmart%2Fidp%2Fredirect&scope=launch&state=smart-auth-static-bytes-not-random-mock"
+  );
+});
+
+test("a slash is included in the url - this should re-direct us to th", async () => {
+  const response = await app.inject({
+    method: "GET",
+    url: "/smart/idp/auth",
+  });
+
+  expect(response.headers["location"]).toBe(
+    "http://external.localhost/test/oauth/authorize?response_type=code&client_id=123&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fsmart%2Fidp%2Fredirect&scope=launch&state=smart-auth-static-bytes-not-random-mock"
+  );
+});
 
 // @todo this requires implementing a mocked oauth server response
-test.todo("a callback url (in the server fixture) is successfully callable") 
+test.todo("a callback url (in the server fixture) is successfully callable");
 //, async () => {
 //   const response = await app.inject({
 //     method: 'GET',
@@ -34,4 +45,3 @@ test.todo("a callback url (in the server fixture) is successfully callable")
 
 //   expect(response.statusCode).toBe(200)
 // })
-

--- a/src/smart-auth/index.ts
+++ b/src/smart-auth/index.ts
@@ -41,7 +41,7 @@ export type SmartAuthProvider = {
     /** A required host name for the auth code exchange redirect path. */
     host: string;
     /** An optional authorize path override. */
-    path?: string | undefined;
+    path?: string;
   };
   /** The default host name for the authorization service. Used to redirect users to the authorization URL. */
   iss: string;

--- a/src/smart-auth/index.ts
+++ b/src/smart-auth/index.ts
@@ -21,13 +21,13 @@ export type SmartAuthProvider = {
     secret: string;
   }
   /** Auth related config */
-  auth?: {
+  auth: {
     /** An optional prefix to add to every route path */
     pathPrefix?: string;
     /** Optional params to append to the authorization redirect */
     authorizeParams?: Record<string, any>;
     /** String used to set the host to request the tokens to. Required. */
-    tokenHost?: string;
+    tokenHost: string;
     /** String path to request an access token. Default to /oauth/token. */
     tokenPath?: string;
     /** String path to revoke an access token. Default to /oauth/revoke. */
@@ -41,7 +41,7 @@ export type SmartAuthProvider = {
     /** A required host name for the auth code exchange redirect path. */
     host: string;
     /** An optional authorize path override. */
-    path?: string;
+    path?: string | undefined;
   };
   /** The default host name for the authorization service. Used to redirect users to the authorization URL. */
   iss: string;
@@ -93,14 +93,14 @@ function checkState(state: string) {
 }
 
 const oauthPlugin: FastifyPluginCallback<SmartAuthProvider> = function (http, options, next) {
-  const { name, auth, client, scope, iss, redirect } = options
+  const { name, auth, client, scope, redirect } = options
 
-  const prefix = auth?.pathPrefix || "/smart";
-  const tokenHost = auth?.tokenHost || iss;
-  const authorizeParams = auth?.authorizeParams || {}
+  const prefix                = auth?.pathPrefix || "/smart";
+  const tokenHost             = auth.tokenHost;
+  const authorizeParams       = auth?.authorizeParams || {}
   const authorizeRedirectPath = `${prefix}/${name.toLowerCase()}/auth`
-  const redirectPath = redirect.path || `${prefix}/${name.toLowerCase()}/redirect`
-  const redirectUri = `${redirect.host}${redirectPath}`
+  const redirectPath          = redirect.path || `${prefix}/${name.toLowerCase()}/redirect`
+  const redirectUri           = `${redirect.host}${redirectPath}`
 
   function generateAuthorizationUri() {
     const state = generateState();
@@ -157,6 +157,8 @@ const oauthPlugin: FastifyPluginCallback<SmartAuthProvider> = function (http, op
       getNewAccessTokenUsingRefreshToken,
       generateAuthorizationUri
     })
+
+
   } catch (e) {
     next(e as Error)
     return

--- a/src/smart-auth/index.ts
+++ b/src/smart-auth/index.ts
@@ -93,10 +93,10 @@ function checkState(state: string) {
 }
 
 const oauthPlugin: FastifyPluginCallback<SmartAuthProvider> = function (http, options, next) {
-  const { name, auth, client, scope, iss, redirect } = options
+  const { name, auth, client, scope, redirect } = options
 
   const prefix                = auth?.pathPrefix || "/smart";
-  const tokenHost             = auth.tokenHost || iss;
+  const tokenHost             = auth.tokenHost;
   const authorizeParams       = auth?.authorizeParams || {}
   const authorizeRedirectPath = `${prefix}/${name.toLowerCase()}/auth`
   const redirectPath          = redirect.path || `${prefix}/${name.toLowerCase()}/redirect`

--- a/src/smart-auth/index.ts
+++ b/src/smart-auth/index.ts
@@ -93,10 +93,10 @@ function checkState(state: string) {
 }
 
 const oauthPlugin: FastifyPluginCallback<SmartAuthProvider> = function (http, options, next) {
-  const { name, auth, client, scope, redirect } = options
+  const { name, auth, client, scope, iss, redirect } = options
 
   const prefix                = auth?.pathPrefix || "/smart";
-  const tokenHost             = auth.tokenHost;
+  const tokenHost             = auth.tokenHost || iss;
   const authorizeParams       = auth?.authorizeParams || {}
   const authorizeRedirectPath = `${prefix}/${name.toLowerCase()}/auth`
   const redirectPath          = redirect.path || `${prefix}/${name.toLowerCase()}/redirect`

--- a/test/smart-auth/idp.ts
+++ b/test/smart-auth/idp.ts
@@ -9,7 +9,7 @@ const smartAuthProviderExample: SmartAuthProvider = {
   },
   auth: {
     tokenHost: "http://external.localhost/",
-    authorizePath: "/test/oauth/authorize",
+    authorizePath: "/smart/oauth/authorize",
   },
   redirect: {
     host: "http://localhost:3000",

--- a/test/smart-auth/idp.ts
+++ b/test/smart-auth/idp.ts
@@ -8,13 +8,13 @@ const smartAuthProviderExample: SmartAuthProvider = {
     secret: "somesecret",
   },
   auth: {
-    tokenHost: "http://external.localhost/",
+    tokenHost: "http://external.localhost",
     authorizePath: "/smart/oauth/authorize",
   },
   redirect: {
     host: "http://localhost:3000",
   },
-  iss: "http://external.localhost/",
+  iss: "http://external.localhost/issuer",
 };
 
 export default smartAuthProviderExample;

--- a/test/smart-auth/idp.ts
+++ b/test/smart-auth/idp.ts
@@ -5,13 +5,16 @@ const smartAuthProviderExample: SmartAuthProvider = {
   scope: ["launch"],
   client: {
     id: "123",
-    secret: "somesecret"
+    secret: "somesecret",
   },
-  auth: {},
+  auth: {
+    tokenHost: "http://external.localhost/",
+    authorizePath: "/test/oauth/authorize",
+  },
   redirect: {
-    host: "http://localhost:3000"
+    host: "http://localhost:3000",
   },
-  iss: "http://external.localhost/test"
-}
+  iss: "http://external.localhost/",
+};
 
 export default smartAuthProviderExample;

--- a/test/smart-auth/idp.ts
+++ b/test/smart-auth/idp.ts
@@ -11,7 +11,7 @@ const smartAuthProviderExample: SmartAuthProvider = {
   redirect: {
     host: "http://localhost:3000"
   },
-  iss: "http://external.localhost/smart/"
+  iss: "http://external.localhost/test"
 }
 
 export default smartAuthProviderExample;


### PR DESCRIPTION
This PR:

- Makes `auth.tokenHost` a required property
- Keeps `iss` as a required property, but does not include it in the oAuth plugin as a fallback for the required `auth.tokenHost`

It also changes `smart-auth/index.test.ts` and the smart-auth `README` to match a new `smartAuthProviderExample`. This is to document the issue of `smart-oauth2` removing any path present after the domain used in `tokenHost`. 