### PR TITLE
Improved route names for IdPs

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -18,7 +18,7 @@
  * 
  * @example Iterables returned for the search operation:
  * ```typescript
- *  const { searche } = Client("https://r4.smarthealthit.org")
+ *  const { search } = Client("https://r4.smarthealthit.org")
  *  const search = search("Patient");
  *  search.next(); 
  * ```

--- a/src/smart-auth/index.test.ts
+++ b/src/smart-auth/index.test.ts
@@ -43,7 +43,18 @@ describe("an authorize url", () => {
   })
 })
 
-
+describe("a provider with a weird name", () => {
+  test("still has nice pretty URLs", async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: `/smart/bad-name/auth`
+    })
+  
+    expect(response.statusCode).toBe(302)
+    expect(response.headers['location']).toBe("http://external.localhost/smart/oauth/authorize?response_type=code&client_id=123&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fsmart%2Fbad-name%2Fredirect&scope=launch&state=smart-auth-static-bytes-not-random-mock")
+  })
+})
+  
 // @todo this requires implementing a mocked oauth server response
 test.todo("a callback url (in the server fixture) is successfully callable") 
 //, async () => {

--- a/src/smart-auth/index.ts
+++ b/src/smart-auth/index.ts
@@ -107,14 +107,18 @@ function checkState(state: string) {
   new Error('Invalid state')
 }
 
+function routeCase(value: string): string {
+  return value.toLowerCase().replace(/\s/g,'-');
+}
+
 const oauthPlugin: FastifyPluginCallback<SmartAuthProvider> = function (http, options, next) {
   const { name, auth, client, scope: defaultScope, redirect } = options
 
   const prefix                = auth?.pathPrefix || "/smart";
   const tokenHost             = auth.tokenHost;
   const authorizeParams       = auth?.authorizeParams || {}
-  const authorizeRedirectPath = `${prefix}/${name.toLowerCase()}/auth`
-  const redirectPath          = redirect.path || `${prefix}/${name.toLowerCase()}/redirect`
+  const authorizeRedirectPath = `${prefix}/${routeCase(name)}/auth`
+  const redirectPath          = redirect.path || `${prefix}/${routeCase(name)}/redirect`
   const redirectUri           = `${redirect.host}${redirectPath}`
 
   function generateAuthorizationUri(scope?: SmartAuthScope[]) {

--- a/test/fixtures/authServer.ts
+++ b/test/fixtures/authServer.ts
@@ -1,4 +1,4 @@
-import smartAuthProviderExample from "../smart-auth/idp";
+import { smartAuthProviderExample, badNameProviderExample } from "../smart-auth/idp";
 import Fastify from "fastify";
 import {
   SmartAuth,
@@ -16,6 +16,7 @@ declare module 'fastify' {
 export const fastify = Fastify();
 
 fastify.register(SmartAuth, { prefix: '/smart', ...smartAuthProviderExample }) 
+fastify.register(SmartAuth, { prefix: '/smart', ...badNameProviderExample }) 
 
 fastify.get<Querystring>("/smart/idp/redirect", QuerystringAjvSchema, async function (request, reply) {
   const response = await this.idp.getAccessTokenFromAuthorizationCodeFlow(request)

--- a/test/smart-auth/idp.ts
+++ b/test/smart-auth/idp.ts
@@ -1,6 +1,6 @@
 import { SmartAuthProvider } from "../../src";
 
-const smartAuthProviderExample: SmartAuthProvider = {
+export const smartAuthProviderExample: SmartAuthProvider = {
   name: "idp",
   scope: ["launch"],
   client: {
@@ -17,4 +17,19 @@ const smartAuthProviderExample: SmartAuthProvider = {
   iss: "http://external.localhost/issuer",
 };
 
-export default smartAuthProviderExample;
+export const badNameProviderExample: SmartAuthProvider = {
+  name: "Bad Name",
+  scope: ["launch"],
+  client: {
+    id: "123",
+    secret: "somesecret",
+  },
+  auth: {
+    tokenHost: "http://external.localhost",
+    authorizePath: "/smart/oauth/authorize",
+  },
+  redirect: {
+    host: "http://localhost:3000",
+  },
+  iss: "http://external.localhost/issuer",
+};


### PR DESCRIPTION
Before, a name like "Bad Name" would produce routes like `/smart/bad name/auth` which are invalid. Now they are will be dashed like `/smart/bad-name/auth`.

See https://github.com/flexpa/sero/pull/131