### PR TITLE
fix: update getAccessTokenFromClientCredentialFlow to take scope as a param

### DIFF
--- a/src/smart-auth/README.md
+++ b/src/smart-auth/README.md
@@ -123,6 +123,7 @@ Sero will pass your scoped parameters in its generated authorization URL for you
 * `SmartAuthRedirectQuerystring` is a TS interface that types the Fastify route contraints for the redirect/callback url - see example for use
 * `SmartAuthUrlQuerystring` is a TS interface that types the Fastify route contraints for the auto-generated authorization URL starting point described above. You can customize scopes on a per request basis.
 * `SmartAuthRedirectQuerystringSchema` is the AJV schema definition that corresponds to `SmartAuthRedirectQuerystring`, and can be used in the Fastify runtime - see example for use
+* `getAccessTokenFromClientCredentialFlow` is a function to fetch a `client_credential` access token for a given `SmartAuthProvider`. It will also prioritize the passed in `scope: string[]` over the `smartAuthProvider.scope`, in case you need special scope(s) for this flow. This function is not decorated on the fastify server, so it can be called directly on a `SmartAuthProvider`.
 
 ### Decorators
 

--- a/src/smart-auth/index.test.ts
+++ b/src/smart-auth/index.test.ts
@@ -82,7 +82,6 @@ describe("getAccessTokenFromClientCredentialFlow", () => {
     },
     auth: {
       tokenHost: 'http://localhost/token',
-      clientCredentialsScope: ['Public NonPII'],
     },
     redirect: {
       host: 'http://localhost:3000/smart/smart-stub/auth',

--- a/src/smart-auth/index.ts
+++ b/src/smart-auth/index.ts
@@ -47,8 +47,6 @@ export type SmartAuthProvider = {
     tokenPath?: string;
     /** String path to revoke an access token. Default to /oauth/revoke. */
     revokePath?: string;
-    /** Overrides for client credentials */
-    clientCredentialsScope?: (SmartAuthScope | string)[];
   };
   redirect: {
     /** A required host name for the auth code exchange redirect path. */
@@ -69,6 +67,7 @@ export interface SmartAuthNamespace {
 
   getAccessTokenFromClientCredentialFlow(
     smartAuthProvider: SmartAuthProvider,
+    scope?: string[],
   ): Promise<AccessToken>;
 
   getNewAccessTokenUsingRefreshToken(
@@ -208,6 +207,7 @@ const oauthPlugin: FastifyPluginCallback<SmartAuthProvider> = function (http, op
 
 export const getAccessTokenFromClientCredentialFlow = async (
   smartAuthProvider: SmartAuthProvider,
+  scope?: string[]
 ): Promise<AccessToken | undefined> => {
   const clientCredentialsOptions = {
     client: smartAuthProvider.client,
@@ -219,7 +219,7 @@ export const getAccessTokenFromClientCredentialFlow = async (
 
   const client = new ClientCredentials(clientCredentialsOptions);
   const tokenParams = {
-    scope: smartAuthProvider.auth?.clientCredentialsScope || smartAuthProvider.scope,
+    scope: scope || smartAuthProvider.scope,
   };
 
   try {


### PR DESCRIPTION
Updates the `getAccessTokenFromClientCredentialFlow` method to have an optional param `scope?: string[]` that can be passed to the client credentials grant flow